### PR TITLE
Update deployment.yml - Fix Map keys must be unique YAML(0) error

### DIFF
--- a/v1/guestbook/deployment.yml
+++ b/v1/guestbook/deployment.yml
@@ -31,4 +31,3 @@ spec:
             cpu: 50m
           requests:
             cpu: 20m  
-  replicas: 1


### PR DESCRIPTION
Fix Map keys must be unique YAML(0) error when applying the deployment in the course (i.e. kubectl apply -f deployment.yaml)