### PR TITLE
Update Dockerfile V2

### DIFF
--- a/v2/guestbook/Dockerfile
+++ b/v2/guestbook/Dockerfile
@@ -1,16 +1,3 @@
-# Please choose from the below set of Docker commands to complete your Dockerfile:
-
-# COPY
-# RUN
-# ADD
-# EXPOSE
-# FROM
-# CMD
-# PUSH
-# PULL
-# WORKDIR
-
-
 FROM golang:1.18 as builder
 
 WORKDIR /app

--- a/v2/guestbook/Dockerfile
+++ b/v2/guestbook/Dockerfile
@@ -1,14 +1,30 @@
-FROM golang:1.15 as builder
-RUN go get github.com/codegangsta/negroni
-RUN go get github.com/xyproto/simpleredis/v2
-RUN go get github.com/gorilla/mux 
+# Please choose from the below set of Docker commands to complete your Dockerfile:
+
+# COPY
+# RUN
+# ADD
+# EXPOSE
+# FROM
+# CMD
+# PUSH
+# PULL
+# WORKDIR
+
+
+FROM golang:1.18 as builder
+
+WORKDIR /app
 
 COPY main.go .
-RUN go build main.go
+
+RUN go mod init guestbook
+RUN go mod tidy
+
+RUN go build -o main main.go
 
 FROM ubuntu:18.04
 
-COPY --from=builder /go//main /app/guestbook
+COPY --from=builder /app/main /app/guestbook
 
 ADD public/index.html /app/public/index.html
 ADD public/script.js /app/public/script.js
@@ -16,5 +32,6 @@ ADD public/style.css /app/public/style.css
 ADD public/jquery.min.js /app/public/jquery.min.js
 
 WORKDIR /app
+
 CMD ["./guestbook"]
 EXPOSE 3000


### PR DESCRIPTION
Changes have been made to the Dockerfile for Guestbook V1. This lab is optional and is linked to Guestbook V2, hence the Dockerfile needed to be updated to align with Guestbook V1.